### PR TITLE
Unset block subject. Fixes empty H2 element on icon blocks

### DIFF
--- a/stanford_bean_types.module
+++ b/stanford_bean_types.module
@@ -150,7 +150,7 @@ function stanford_bean_types_block_view_alter(&$data, $block) {
   // If the block is an icon block we want to remove the subject.
   if ($block->module == "bean") {
     if ($data["content"]["bean"][$block->delta]["#bundle"] == "stanford_icon_block") {
-      $data["subject"] = "<none>";
+      $data["subject"] = "";
     }
   }
 


### PR DESCRIPTION
Let's try this.
1. Create and place an icon block.
2. See `<h2><none></h2>` code on the page.
3. Run the WAVE test on the page at wave.webaim.org. See failure for empty `<h2>` tag.
4. Check out this branch
5. Clear caches and try step #2 and #3 again. You should not see `<h2><none></h2>` and the WAVE test should pass.
