### PR TITLE
Probotest rebase withoutforce

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -6,9 +6,8 @@ steps:
     plugin: Script
     script: |
       # Test variables
-      test_feature='stanford_bean_types'
       test_deployer_product='jumpstart-academic'
-      test_product_profile='stanford_sites_jumpstart_academic'
+      test_feature=$(cd /src | echo *.info | cut -f1 -d".")
       # Server setup
       cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa
       chmod 400 ~/.ssh/id_rsa
@@ -19,22 +18,25 @@ steps:
       source /root/.bash_profile
       mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root')";
       mysql -u root -proot -e "CREATE DATABASE html";
+      # Downloading Probo CI Assets
+      git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
+      cp /srv/proboci_assets/.my.cnf /root/.my.cnf
       # Installing drush
       sudo mkdir --parents /opt/drush-8.x
       cd /opt/drush-8.x
       sudo composer init --require=drush/drush:8.* -n
       sudo composer config bin-dir /usr/local/bin
-      sudo composer install >/dev/null
-      # Downloading Probo CI Assets
-      git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
+      sudo composer install &>/dev/null &
+      # Installing parallel
+      (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
       # Installing node modules
       npm install -g npm >/dev/null
-      npm install -g gm webdrivercss webdriverio selenium-standalone chromedriver >/dev/null
+      npm install -g selenium-standalone chromedriver >/dev/null
+      selenium-standalone install --silent
       # Installing BeHat
       git clone https://github.com/SU-SWS/linky_clicky.git /srv/linky_clicky
       cd /srv/linky_clicky
-      composer install >/dev/null
-      selenium-standalone install >/dev/null
+      composer install &>/dev/null &
       cp /srv/proboci_assets/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
       cp /srv/linky_clicky/includes/features/SU-SWS/$test_feature/$test_feature.feature /srv/linky_clicky/sites/probo/features/.
       # Downloading and running Jumpstart Deployer
@@ -42,12 +44,20 @@ steps:
       cd /srv/stanford-jumpstart-deployer
       drush make development/product/$test_deployer_product/$test_deployer_product.make /var/www/html
       cp /srv/proboci_assets/.htaccess /var/www/html/.htaccess
+      mkdir -p /var/www/html/sites/default/files/styles
+      chmod -R 777 /var/www/html/sites/default/files
   - name: Building site
-    command: 'service mysql start; cd /var/www/html; drush si $test_product_profile --account-name=admin --db-url="mysql://root:root@localhost/html"'
+    command: '
+      df -h;
+      cd /var/www/html/profiles;
+      test_product_profile=$(echo stanford_sites_jumpstart_*);
+      service mysql start;
+      service mysql reload;
+      service mysql restart;
+      cd /var/www/html;
+      drush si $test_product_profile --account-name=admin --db-url="mysql://root:root@localhost/html"'
   - name: Run relevant Behat tests
-    script: |
-      ls -la /var/www/html/sites/default/files
-      cat /var/www/html/sites/default/files/.htaccess
-      nohup selenium-standalone start &>/dev/null &
-      cd /srv/linky_clicky/sites/probo
-      /srv/linky_clicky/bin/behat features/$test_feature.feature --profile default --suite dev --format pretty
+    command: '
+      test_feature=$(cd /src | echo *.info | cut -f1 -d".");
+      cd /srv/linky_clicky/sites/probo;
+      parallel ::: "nohup selenium-standalone start &>/dev/null &" "/srv/linky_clicky/bin/behat features/$test_feature.feature --profile default --suite dev --format pretty"'

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,67 +1,63 @@
 assets:
-  - db.sql.gz
-  - aliases.drushrc.php
-  - behat.local.yml
-  - .shoov.json
-  - package.json
-  - tests.js
+  - ngrok.yml
   - .shoov.yml
 steps:
   - name: Download Drupal Behat and Shoov
     plugin: Script
     script: |
-      sudo apt-get update
-      sudo apt-get -y install python-software-properties software-properties-common
-      sudo add-apt-repository ppa:pi-rho/dev
-      sudo apt-get update
-      sudo apt-get -y install tmux
-      drush dl drupal-7.x --destination=/var/www
-      mkdir .drush
-      echo $ASSET_DIR/aliases.drushrc.php > .drush/aliases.drushrc.php
-      mv /var/www/drupal-7.x-dev /var/www/html
-      echo 'Downloaded drupal-7.x and moved it to /var/www/html'
-      cp $ASSET_DIR/aliases.drushrc.php /root/.drush/aliases.drushrc.php
-      echo 'Saved drush aliases file'
+      echo 'Download Probo CI assets'
+      git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
+      echo 'Install ngrok'
+      echo "127.0.0.1 html" >> /etc/hosts
+      wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip -O /srv/ngrok.zip
+      unzip /srv/ngrok.zip -d /srv
+      cp /srv/proboci_assets/ngrok.yml /srv/ngrok.yml
+      (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
+      echo 'Install node modules'
+      npm install -g npm
+      npm install -g grunt-cli mocha gm webdrivercss webdriverio selenium-standalone chromedriver
+      echo 'Install Geppetto'
+      git clone https://github.com/SU-SWS/stanford_geppetto.git /srv/stanford_geppetto
+      cd /srv/stanford_geppetto
+      npm install
+      cp /srv/proboci_assets/configure.json /srv/stanford_geppetto/configure.json
+      echo 'Build site'
+      cd /srv/stanford_geppetto
+      grunt build:make:install --build-product=jumpstart-academic --build-environment=production --build-type=production --build-directory=/var/www/html --build-database-user=root --build-database-pass=root --build-database-name=html
+      echo 'Enable relevant modules'
+      mkdir -p /var/www/html/sites/all/modules/stanford/stanford_bean_types
+      chown -R www-data:www-data /var/www/html/sites/default/files
+      cd /var/www/html
+      drush dl features ds bean
+      drush en -y features bean_admin_ui ds_extras
+      drush fra -y
+      drush dis overlay -y
+      drush updb -y
+      drush cc all -y
+      echo 'Download behat tests and start selenium server'
       git clone https://github.com/SU-SWS/linky_clicky.git /srv/linky_clicky
       cd /srv/linky_clicky
       composer install
-      echo 'Downloaded linky_clicky to /srv/linky_clicky and ran composer install'
-      npm install -g npm
-      npm install -g mocha gm webdrivercss webdriverio selenium-standalone chromedriver
       selenium-standalone install
-      nohup selenium-standalone start &>/dev/null &
-      cp $ASSET_DIR/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
-      echo 'Downloaded tmux and node packages and started selenium in the background'
-      cp $ASSET_DIR/.shoov.json /root/.shoov.json
+      git checkout shoov
+      cp /srv/proboci_assets/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
+      echo 'Download shoov tests'
+      cp $ASSETS_DIR/.shoov.json /root/.shoov.json
       mkdir -p /srv/linky_clicky/sites/probo/visual-monitor/test
-      cp $ASSET_DIR/package.json /srv/linky_clicky/sites/probo/package.json
+      cp /srv/proboci_assets/package.json /srv/linky_clicky/sites/probo/package.json
       cd /srv/linky_clicky/sites/probo
       npm install
-      cp $ASSET_DIR/.shoov.yml /srv/linky_clicky/sites/probo/.shoov.yml
+      cp /srv/proboci_assets/.shoov.yml /srv/linky_clicky/sites/probo/.shoov.yml
       mkdir /srv/linky_clicky/sites/probo/visual-monitor/webdrivercss
-  - name: Probo CI site setup
-    plugin: Drupal
-    database: db.sql.gz
-    databaseGzipped: true
-    databaseUpdates: true
-    clearCaches: true
-  - name: Install and Enable Module
+  - name: Copy relevant tests
     script: |
-      mkdir /var/www/html/sites/all/modules/stanford && mkdir /var/www/html/sites/all/modules/stanford/stanford_bean_types
-      mv /src/* /var/www/html/sites/all/modules/stanford/stanford_bean_types/
-      chown -R www-data:www-data /var/www/html/sites/default/files
-      drush --root=/var/www/html dl features ds bean -y && drush --root=/var/www/html en features bean_admin_ui ds_extras
-      git clone https://github.com/SU-SWS/stanford_image.git /var/www/html/sites/all/modules/stanford/stanford_image && git clone https://github.com/SU-SWS/stanford_image_styles.git /var/www/html/sites/all/modules/stanford/stanford_image_styles
-      drush --root=/var/www/html en stanford_bean_types -y
-      drush --root="/var/www/html" fra -y
-      drush dis overlay -y
-      drush --root="/var/www/html" updb -y
-      drush --root="/var/www/html" cc all -y
-  - name: Copy relevant Behat tests
-    command: 'cp /srv/linky_clicky/includes/features/SU-SWS/stanford_bean_types/stanford_bean_types.feature /srv/linky_clicky/sites/probo/features/.'
+      cp /srv/linky_clicky/includes/features/SU-SWS/stanford_bean_types/stanford_bean_types.feature /srv/linky_clicky/sites/probo/features/.
+      cp /srv/proboci_assets/tests.js /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js
+      sed -i -e 's/PROBO_BUILD_DOMAIN/$BUILD_DOMAIN/' /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js
   - name: Run relevant Behat tests
-    command: 'cd /srv/linky_clicky/sites/probo; /srv/linky_clicky/bin/behat features/stanford_bean_types.feature --profile default --suite dev --format progress --tags "~@javascript"'
-  - name: Copy relevant Shoov tests
-    command: "cp $ASSET_DIR/tests.js /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js; sed -i -e 's/PROBO_BUILD_DOMAIN/$BUILD_DOMAIN/' /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js"
+    script: |
+      nohup selenium-standalone start &>/dev/null &
+      cd /srv/linky_clicky/sites/probo
+      /srv/linky_clicky/bin/behat features/stanford_bean_types.feature --profile default --suite dev
   - name: Run relevant Shoov tests
-    command: 'tmux new -s shoov -d; tmux list; cd /srv/linky_clicky/sites/probo/visual-monitor; PROVIDER_PREFIX=browserstack SELECTED_CAPS=chrome mocha'
+    command: "cd /srv/linky_clicky/sites/probo/visual-monitor; parallel ::: 'timeout 30s /srv/ngrok start -config /srv/ngrok.yml html' 'PROVIDER_PREFIX=browserstack SELECTED_CAPS=chrome mocha'"

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,0 +1,67 @@
+assets:
+  - db.sql.gz
+  - aliases.drushrc.php
+  - behat.local.yml
+  - .shoov.json
+  - package.json
+  - tests.js
+  - .shoov.yml
+steps:
+  - name: Download Drupal Behat and Shoov
+    plugin: Script
+    script: |
+      sudo apt-get update
+      sudo apt-get -y install python-software-properties software-properties-common
+      sudo add-apt-repository ppa:pi-rho/dev
+      sudo apt-get update
+      sudo apt-get -y install tmux
+      drush dl drupal-7.x --destination=/var/www
+      mkdir .drush
+      echo $ASSET_DIR/aliases.drushrc.php > .drush/aliases.drushrc.php
+      mv /var/www/drupal-7.x-dev /var/www/html
+      echo 'Downloaded drupal-7.x and moved it to /var/www/html'
+      cp $ASSET_DIR/aliases.drushrc.php /root/.drush/aliases.drushrc.php
+      echo 'Saved drush aliases file'
+      git clone https://github.com/SU-SWS/linky_clicky.git /srv/linky_clicky
+      cd /srv/linky_clicky
+      composer install
+      echo 'Downloaded linky_clicky to /srv/linky_clicky and ran composer install'
+      npm install -g npm
+      npm install -g mocha gm webdrivercss webdriverio selenium-standalone chromedriver
+      selenium-standalone install
+      nohup selenium-standalone start &>/dev/null &
+      cp $ASSET_DIR/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
+      echo 'Downloaded tmux and node packages and started selenium in the background'
+      cp $ASSET_DIR/.shoov.json /root/.shoov.json
+      mkdir -p /srv/linky_clicky/sites/probo/visual-monitor/test
+      cp $ASSET_DIR/package.json /srv/linky_clicky/sites/probo/package.json
+      cd /srv/linky_clicky/sites/probo
+      npm install
+      cp $ASSET_DIR/.shoov.yml /srv/linky_clicky/sites/probo/.shoov.yml
+      mkdir /srv/linky_clicky/sites/probo/visual-monitor/webdrivercss
+  - name: Probo CI site setup
+    plugin: Drupal
+    database: db.sql.gz
+    databaseGzipped: true
+    databaseUpdates: true
+    clearCaches: true
+  - name: Install and Enable Module
+    script: |
+      mkdir /var/www/html/sites/all/modules/stanford && mkdir /var/www/html/sites/all/modules/stanford/stanford_bean_types
+      mv /src/* /var/www/html/sites/all/modules/stanford/stanford_bean_types/
+      chown -R www-data:www-data /var/www/html/sites/default/files
+      drush --root=/var/www/html dl features ds bean -y && drush --root=/var/www/html en features bean_admin_ui ds_extras
+      git clone https://github.com/SU-SWS/stanford_image.git /var/www/html/sites/all/modules/stanford/stanford_image && git clone https://github.com/SU-SWS/stanford_image_styles.git /var/www/html/sites/all/modules/stanford/stanford_image_styles
+      drush --root=/var/www/html en stanford_bean_types -y
+      drush --root="/var/www/html" fra -y
+      drush dis overlay -y
+      drush --root="/var/www/html" updb -y
+      drush --root="/var/www/html" cc all -y
+  - name: Copy relevant Behat tests
+    command: 'cp /srv/linky_clicky/includes/features/SU-SWS/stanford_bean_types/stanford_bean_types.feature /srv/linky_clicky/sites/probo/features/.'
+  - name: Run relevant Behat tests
+    command: 'cd /srv/linky_clicky/sites/probo; /srv/linky_clicky/bin/behat features/stanford_bean_types.feature --profile default --suite dev --format progress --tags "~@javascript"'
+  - name: Copy relevant Shoov tests
+    command: "cp $ASSET_DIR/tests.js /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js; sed -i -e 's/PROBO_BUILD_DOMAIN/$BUILD_DOMAIN/' /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js"
+  - name: Run relevant Shoov tests
+    command: 'tmux new -s shoov -d; tmux list; cd /srv/linky_clicky/sites/probo/visual-monitor; PROVIDER_PREFIX=browserstack SELECTED_CAPS=chrome mocha'

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,13 +1,15 @@
 assets:
-  - ngrok.yml
-  - .shoov.json
-  - .shoov.yml
   - proboci_id_rsa
   - proboci_id_rsa.pub
 steps:
-  - name: Download Drupal Behat and Shoov
+  - name: Setting up server and installing applications
     plugin: Script
     script: |
+      # Test variables
+      test_feature='stanford_bean_types'
+      test_deployer_product='jumpstart-academic'
+      test_product_profile='stanford_sites_jumpstart_academic'
+      # Server setup
       cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa
       chmod 400 ~/.ssh/id_rsa
       cp $ASSET_DIR/proboci_id_rsa.pub /root/.ssh/id_rsa.pub
@@ -15,67 +17,37 @@ steps:
       echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bash_profile
       echo 'export PATH="/usr/bin/mysql:$PATH"' >> /root/.bash_profile
       source /root/.bash_profile
+      mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root')";
+      mysql -u root -proot -e "CREATE DATABASE html";
+      # Installing drush
       sudo mkdir --parents /opt/drush-8.x
       cd /opt/drush-8.x
       sudo composer init --require=drush/drush:8.* -n
       sudo composer config bin-dir /usr/local/bin
-      sudo composer install
-      mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root')";
-      echo 'Download Probo CI assets'
+      sudo composer install >/dev/null
+      # Downloading Probo CI Assets
       git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
-      echo 'Install ngrok'
-      wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip -O /srv/ngrok.zip
-      unzip /srv/ngrok.zip -d /srv
-      cp $ASSET_DIR/ngrok.yml /srv/ngrok.yml
-      # (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
-      echo 'Install node modules'
+      # Installing node modules
       npm install -g npm >/dev/null
-      npm install -g grunt-cli mocha gm webdrivercss webdriverio selenium-standalone chromedriver
-      sudo chown -R root:`id -g -n root` /root/.npm
-      echo 'Install Geppetto'
-      git clone https://github.com/SU-SWS/stanford_geppetto.git /srv/stanford_geppetto
-      cd /srv/stanford_geppetto
-      git checkout proboci
-      npm install
-      cp /srv/proboci_assets/configure.json /srv/stanford_geppetto/configure.json
-      cd /srv/stanford_geppetto
-      sudo grunt build:make:install --system-drush=/usr/local/bin/drush --build-directory=/var/www/html --build-product=jumpstart-academic --build-database-name=html
-      echo 'Enable relevant modules'
-      mkdir -p /var/www/html/sites/all/modules/stanford/stanford_bean_types
-      chown -R www-data:www-data /var/www/html/sites/default/files
-      cd /var/www/html
-      drush dl features ds bean
-      drush en -y features bean_admin_ui ds_extras
-      drush fra -y
-      drush dis overlay -y
-      drush updb -y
-      drush cc all -y
-      echo 'Download behat tests and start selenium server'
+      npm install -g gm webdrivercss webdriverio selenium-standalone chromedriver >/dev/null
+      # Installing BeHat
       git clone https://github.com/SU-SWS/linky_clicky.git /srv/linky_clicky
       cd /srv/linky_clicky
-      composer install
-      selenium-standalone install
-      git checkout shoov
+      composer install >/dev/null
+      selenium-standalone install >/dev/null
       cp /srv/proboci_assets/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
-      echo 'Download shoov tests'
-      cp $ASSET_DIR/.shoov.json /root/.shoov.json
-      mkdir -p /srv/linky_clicky/sites/probo/visual-monitor/test
-      cp /srv/proboci_assets/package.json /srv/linky_clicky/sites/probo/package.json
-      cd /srv/linky_clicky/sites/probo
-      npm install
-      cp /srv/proboci_assets/.shoov.yml /srv/linky_clicky/sites/probo/.shoov.yml
-      mkdir /srv/linky_clicky/sites/probo/visual-monitor/webdrivercss
-      echo 'Setting 127.0.0.1 to html after loading database' 
-      echo "127.0.0.1 html" >> /etc/hosts
-  - name: Copy relevant tests
-    script: |
-      cp /srv/linky_clicky/includes/features/SU-SWS/stanford_bean_types/stanford_bean_types.feature /srv/linky_clicky/sites/probo/features/.
-      cp /srv/proboci_assets/tests.js /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js
-      sed -i -e 's/PROBO_BUILD_DOMAIN/$BUILD_DOMAIN/' /srv/linky_clicky/sites/probo/visual-monitor/test/tests.js
+      cp /srv/linky_clicky/includes/features/SU-SWS/$test_feature/$test_feature.feature /srv/linky_clicky/sites/probo/features/.
+      # Downloading and running Jumpstart Deployer
+      git clone git@github.com:SU-SWS/stanford-jumpstart-deployer.git /srv/stanford-jumpstart-deployer
+      cd /srv/stanford-jumpstart-deployer
+      drush make development/product/$test_deployer_product/$test_deployer_product.make /var/www/html
+      cp /srv/proboci_assets/.htaccess /var/www/html/.htaccess
+  - name: Building site
+    command: 'service mysql start; cd /var/www/html; drush si $test_product_profile --account-name=admin --db-url="mysql://root:root@localhost/html"'
   - name: Run relevant Behat tests
     script: |
+      ls -la /var/www/html/sites/default/files
+      cat /var/www/html/sites/default/files/.htaccess
       nohup selenium-standalone start &>/dev/null &
       cd /srv/linky_clicky/sites/probo
-      /srv/linky_clicky/bin/behat features/stanford_bean_types.feature --profile default --suite dev
-  - name: Run relevant Shoov tests
-    command: "cd /srv/linky_clicky/sites/probo/visual-monitor; parallel ::: 'timeout 30s /srv/ngrok start -config /srv/ngrok.yml html' 'PROVIDER_PREFIX=browserstack SELECTED_CAPS=chrome mocha'"
+      /srv/linky_clicky/bin/behat features/$test_feature.feature --profile default --suite dev --format pretty

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,17 +1,26 @@
 assets:
   - ngrok.yml
+  - .shoov.json
   - .shoov.yml
+  - proboci_id_rsa
+  - proboci_id_rsa.pub
 steps:
   - name: Download Drupal Behat and Shoov
     plugin: Script
     script: |
+      cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa
+      cp $ASSET_DIR/proboci_id_rsa.pub /root/.ssh/id_rsa.pub
+      git clone git@github.com:SU-SWS/stanford_sites_jumpstart_academic.git /srv/stanford_sites_jumpstart_academic
+      service mysql start
+      echo 'export PATH="/usr/bin/mysql:$PATH"' >> /root/.bash_profile
+      source /root/.bash_profile
+      mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root')";
       echo 'Download Probo CI assets'
       git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
       echo 'Install ngrok'
-      echo "127.0.0.1 html" >> /etc/hosts
       wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip -O /srv/ngrok.zip
       unzip /srv/ngrok.zip -d /srv
-      cp /srv/proboci_assets/ngrok.yml /srv/ngrok.yml
+      cp $ASSET_DIR/ngrok.yml /srv/ngrok.yml
       (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
       echo 'Install node modules'
       npm install -g npm
@@ -19,11 +28,12 @@ steps:
       echo 'Install Geppetto'
       git clone https://github.com/SU-SWS/stanford_geppetto.git /srv/stanford_geppetto
       cd /srv/stanford_geppetto
+      git checkout proboci
       npm install
       cp /srv/proboci_assets/configure.json /srv/stanford_geppetto/configure.json
       echo 'Build site'
       cd /srv/stanford_geppetto
-      grunt build:make:install --build-product=jumpstart-academic --build-environment=production --build-type=production --build-directory=/var/www/html --build-database-user=root --build-database-pass=root --build-database-name=html
+      grunt build:make:install --build-product=jumpstart-academic --build-database-name=html
       echo 'Enable relevant modules'
       mkdir -p /var/www/html/sites/all/modules/stanford/stanford_bean_types
       chown -R www-data:www-data /var/www/html/sites/default/files
@@ -42,13 +52,15 @@ steps:
       git checkout shoov
       cp /srv/proboci_assets/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
       echo 'Download shoov tests'
-      cp $ASSETS_DIR/.shoov.json /root/.shoov.json
+      cp $ASSET_DIR/.shoov.json /root/.shoov.json
       mkdir -p /srv/linky_clicky/sites/probo/visual-monitor/test
       cp /srv/proboci_assets/package.json /srv/linky_clicky/sites/probo/package.json
       cd /srv/linky_clicky/sites/probo
       npm install
       cp /srv/proboci_assets/.shoov.yml /srv/linky_clicky/sites/probo/.shoov.yml
       mkdir /srv/linky_clicky/sites/probo/visual-monitor/webdrivercss
+      echo 'Setting 127.0.0.1 to html after loading database' 
+      echo "127.0.0.1 html" >> /etc/hosts
   - name: Copy relevant tests
     script: |
       cp /srv/linky_clicky/includes/features/SU-SWS/stanford_bean_types/stanford_bean_types.feature /srv/linky_clicky/sites/probo/features/.

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -9,11 +9,17 @@ steps:
     plugin: Script
     script: |
       cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa
+      chmod 400 ~/.ssh/id_rsa
       cp $ASSET_DIR/proboci_id_rsa.pub /root/.ssh/id_rsa.pub
-      git clone git@github.com:SU-SWS/stanford_sites_jumpstart_academic.git /srv/stanford_sites_jumpstart_academic
       service mysql start
+      echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bash_profile
       echo 'export PATH="/usr/bin/mysql:$PATH"' >> /root/.bash_profile
       source /root/.bash_profile
+      sudo mkdir --parents /opt/drush-8.x
+      cd /opt/drush-8.x
+      sudo composer init --require=drush/drush:8.* -n
+      sudo composer config bin-dir /usr/local/bin
+      sudo composer install
       mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root')";
       echo 'Download Probo CI assets'
       git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
@@ -21,19 +27,19 @@ steps:
       wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip -O /srv/ngrok.zip
       unzip /srv/ngrok.zip -d /srv
       cp $ASSET_DIR/ngrok.yml /srv/ngrok.yml
-      (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
+      # (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
       echo 'Install node modules'
-      npm install -g npm
+      npm install -g npm >/dev/null
       npm install -g grunt-cli mocha gm webdrivercss webdriverio selenium-standalone chromedriver
+      sudo chown -R root:`id -g -n root` /root/.npm
       echo 'Install Geppetto'
       git clone https://github.com/SU-SWS/stanford_geppetto.git /srv/stanford_geppetto
       cd /srv/stanford_geppetto
       git checkout proboci
       npm install
       cp /srv/proboci_assets/configure.json /srv/stanford_geppetto/configure.json
-      echo 'Build site'
       cd /srv/stanford_geppetto
-      grunt build:make:install --build-product=jumpstart-academic --build-database-name=html
+      sudo grunt build:make:install --system-drush=/usr/local/bin/drush --build-directory=/var/www/html --build-product=jumpstart-academic --build-database-name=html
       echo 'Enable relevant modules'
       mkdir -p /var/www/html/sites/all/modules/stanford/stanford_bean_types
       chown -R www-data:www-data /var/www/html/sites/default/files

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -27,12 +27,11 @@ steps:
       sudo composer init --require=drush/drush:8.* -n
       sudo composer config bin-dir /usr/local/bin
       sudo composer install &>/dev/null &
-      # Installing parallel
-      (wget -O - pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3) | bash
       # Installing node modules
       npm install -g npm >/dev/null
       npm install -g selenium-standalone chromedriver >/dev/null
       selenium-standalone install --silent
+      nohup selenium-standalone start &>/dev/null &
       # Installing BeHat
       git clone https://github.com/SU-SWS/linky_clicky.git /srv/linky_clicky
       cd /srv/linky_clicky
@@ -60,4 +59,4 @@ steps:
     command: '
       test_feature=$(cd /src | echo *.info | cut -f1 -d".");
       cd /srv/linky_clicky/sites/probo;
-      parallel ::: "nohup selenium-standalone start &>/dev/null &" "/srv/linky_clicky/bin/behat features/$test_feature.feature --profile default --suite dev --format pretty"'
+      /srv/linky_clicky/bin/behat features/$test_feature.feature --profile default --suite dev --format pretty'

--- a/stanford_bean_types.module
+++ b/stanford_bean_types.module
@@ -207,8 +207,3 @@ function stanford_bean_types_form_bean_form_alter(&$form, $form_state, $form_id)
   $form['view_mode']['#options'] = $options;
 
 }
-
-
-/**
- * This is an errant code block to test https://app.probo.ci
- */

--- a/stanford_bean_types.module
+++ b/stanford_bean_types.module
@@ -209,4 +209,6 @@ function stanford_bean_types_form_bean_form_alter(&$form, $form_state, $form_id)
 }
 
 
-
+/**
+ * This is an errant code block to test https://app.probo.ci
+ */


### PR DESCRIPTION
Hello Shea.  My fear of using git push -f led me to create a new branch where I could push the rebased git history.  This is that branch; please let me know if these commit messages are sufficiently detailed.

Once reviewed and approved, we should be able to delete the following branches: probotest, probotest-test, probotest-rebase, and probotest-rebase-withoutforce.  In the future, I think the best practice might be to rebase on probotest-test, and only afterwards create a new branch which I then push.  Creating probotest-rebase at the beginning of the rebase process caused two problems: 1. git wanted a remote branch, so I had to push it.  Then 2. after the rebase was over, I would have had to used git push -f because the probotest-rebase remote branch contained the 250+ commits from probotest-test.

Also, in case this is useful feedback: I like how squash (unlike fixup) appends the commit messages we are leaving behind to the few commit messages we are keeping.  I think the messages squashed are sufficiently detailed to give anyone a good picture of what was tried and when it was abandoned.  Even still, I forked the repository to my personal account because...just in case.
