### PR TITLE
Build self-service site for testing

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -9,8 +9,7 @@ assets:
 # Uncomment and place between downloading the proboci_assets repository and running the probo.sh script.
 # Add which product you would like to build by running the script with the name of the profile,
 # ie. /srv/proboci_assets/probo.sh jumpstart-academic
-# Choices include stanford, jumpstart, jumpstart-academic, jumpstart-engineering
-# And jumpstart-plus
+# Choices include stanford, jumpstart, jumpstart-academic, etc.
 
 steps:
   - name: Run tests from external proboci_assets repository

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,78 +1,21 @@
-# Several guidelines that I tried to follow when writing this file:
-# 1. Limit Probo CI steps to what we are interested in testing.
-# 2. Limit stdout to what might break or returns test results, which also speeds up builds.
-# 3. Limit what we must upload as assets to what we cannot push to public repositories.
-# 4. Similarly, make it as easy as possible to copy this file to new repositories.
-# 5. To specify the full path, ie. /root/directory, rather than ~/directory.
-#
-# Potential improvements
-# 1. Use Probo CI's Drupal plugin for building products, instead of the deployer.
-# 2. Or using Geppetto, instead of the deployer.
-# 3. Test whether Behat tests requiring @javascript will run with selenium in a separate shell.
-# 4. Right now, my profile variable would not work for JSV, as it assumes a jumpstart_ suffix.
-#
+# This file includes the minimum code required to build and test a site with ProboCI.
+# All other code is stored in SU-SWS/proboci_assets and should be updated there.
+# Best methods for managing keys is still up for discussion.
+
+# Uncomment if building a product other than a self-service site.
 assets:
-  - proboci_id_rsa
-  - proboci_id_rsa.pub
+ - proboci_id_rsa
+ - proboci_id_rsa.pub
+
+# Uncomment and place between downloading the proboci_assets repository and running the probo.sh script.
+# Add which product you would like to build by running the script with the name of the profile,
+# ie. /srv/proboci_assets/probo.sh jumpstart-academic
+# Choices include stanford, jumpstart, jumpstart-academic, jumpstart-engineering
+# And jumpstart-plus
+
 steps:
-  - name: Setting up server and installing applications
-    plugin: Script
-    script: |
-      # Set Feature and Product-specific variables
-      test_deployer_product='jumpstart-academic'
-      test_feature=$(cd /src | echo *.info | cut -f1 -d".")
-      # Configure keys and MySQL
-      cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa
-      chmod 400 ~/.ssh/id_rsa
-      cp $ASSET_DIR/proboci_id_rsa.pub /root/.ssh/id_rsa.pub
-      service mysql start
-      echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bash_profile
-      echo 'export PATH="/usr/bin/mysql:$PATH"' >> /root/.bash_profile
-      source /root/.bash_profile
-      mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root')";
-      mysql -u root -proot -e "CREATE DATABASE html";
-      # Downloading Probo CI Assets
-      git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets
-      cp /srv/proboci_assets/.my.cnf /root/.my.cnf
-      # Installing drush 8
-      sudo mkdir --parents /opt/drush-8.x
-      cd /opt/drush-8.x
-      sudo composer init --require=drush/drush:8.* -n
-      sudo composer config bin-dir /usr/local/bin
-      sudo composer install &>/dev/null &
-      # Installing node modules
-      npm install -g npm >/dev/null
-      npm install -g selenium-standalone chromedriver >/dev/null
-      selenium-standalone install --silent
-      # Probo CI fails to start selenium-standalone start when run with their command plugin.
-      # But we might need to start selenium in the same shell as we run Behat tests.
-      # And force Probo CI to display Behat test results, if using their script plugin.
-      nohup selenium-standalone start &>/dev/null &
-      # Installing Behat
-      git clone https://github.com/SU-SWS/linky_clicky.git /srv/linky_clicky
-      cd /srv/linky_clicky
-      composer install &>/dev/null &
-      cp /srv/proboci_assets/behat.local.yml /srv/linky_clicky/sites/probo/behat.local.yml
-      cp /srv/linky_clicky/includes/features/SU-SWS/$test_feature/$test_feature.feature /srv/linky_clicky/sites/probo/features/.
-      # Downloading and running Jumpstart Deployer
-      git clone git@github.com:SU-SWS/stanford-jumpstart-deployer.git /srv/stanford-jumpstart-deployer
-      cd /srv/stanford-jumpstart-deployer
-      drush make development/product/$test_deployer_product/$test_deployer_product.make /var/www/html
-      cp /srv/proboci_assets/.htaccess /var/www/html/.htaccess
-      mkdir -p /var/www/html/sites/default/files/styles
-      chmod -R 777 /var/www/html/sites/default/files
-  - name: Building site
-    command: '
-      df -h;
-      cd /var/www/html/profiles;
-      test_product_profile=$(echo stanford_sites_jumpstart_*);
-      service mysql start;
-      service mysql reload;
-      service mysql restart;
-      cd /var/www/html;
-      drush si $test_product_profile --account-name=admin --db-url="mysql://root:root@localhost/html"'
-  - name: Run relevant Behat tests
-    command: '
-      test_feature=$(cd /src | echo *.info | cut -f1 -d".");
-      cd /srv/linky_clicky/sites/probo;
-      /srv/linky_clicky/bin/behat features/$test_feature.feature --profile default --suite dev --format pretty'
+  - name: Run tests from external proboci_assets repository
+    command: "git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets;
+      cp $ASSET_DIR/proboci_id_rsa.pub /root/.ssh/id_rsa.pub;
+      cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa;
+      /srv/proboci_assets/probo.sh stanford"

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,6 +1,5 @@
 # This file includes the minimum code required to build and test a site with ProboCI.
 # All other code is stored in SU-SWS/proboci_assets and should be updated there.
-# Best methods for managing keys is still up for discussion.
 
 # Uncomment if building a product other than a self-service site.
 assets:
@@ -18,4 +17,4 @@ steps:
     command: "git clone https://github.com/SU-SWS/proboci_assets.git /srv/proboci_assets;
       cp $ASSET_DIR/proboci_id_rsa.pub /root/.ssh/id_rsa.pub;
       cp $ASSET_DIR/proboci_id_rsa /root/.ssh/id_rsa;
-      /srv/proboci_assets/probo.sh stanford"
+      /srv/proboci_assets/probo.sh"


### PR DESCRIPTION
Hello Shea.  Please let me know if this looks ready to merge.  The script now calls and builds a site from: https://github.com/SU-SWS/proboci_assets/blob/1.x/probo.sh.  I tested that it can build a self-service site and a jumpstart product.