### PR TITLE
SOE-1641: clean up logs, fix Notice: Undefined index: content

### DIFF
--- a/stanford_bean_types.module
+++ b/stanford_bean_types.module
@@ -149,11 +149,12 @@ function stanford_bean_types_block_view_alter(&$data, $block) {
 
   // If the block is an icon block we want to remove the subject.
   if ($block->module == "bean") {
-    if ($data["content"]["bean"][$block->delta]["#bundle"] == "stanford_icon_block") {
-      $data["subject"] = "";
+    if (isset($data["content"])) {
+      if ($data["content"]["bean"][$block->delta]["#bundle"] == "stanford_icon_block") {
+        $data["subject"] = "";
+      }
     }
   }
-
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This error is filling the logs on https://insidesoe.stanford.edu/. Want to clear this out so we can better track the disappearing faculty affairs menu, and to clean up the logs. 

# Needed By (Date)
- TBD

# Urgency
- Not urgent

# Steps to Test

1. Log into https://insidesoe.stanford.edu/ (or preferably a copy)
2. On recent log messages at admin/reports/dblog
verify that this notice corresponds with when you logged into the site:
Notice: Undefined index: content in stanford_bean_types_block_view_alter() (line 152 of /afs/.ir.stanford.edu/dist/drupal/ds_jse-soe-intranet/modules/stanford/stanford_bean_types/stanford_bean_types.module).
3. Update stanford_beans_types to include this PR
4. Log out and log in again.
5. At admin/reports/dblog verify that this notice does not appear

# Affected Projects or Products
- Affects any products/projects that use stanford_bean_types

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-1641
- FYI @boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)