### PR TITLE
HSDO-918 Added branding overlay

### DIFF
--- a/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
+++ b/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
@@ -46,3 +46,75 @@ html.js body > .hero-scroll a.scroll-down {
 html.js body > .hero-scroll a.scroll-down .scroll-text {
   font-size: 20px;
 }
+html.js #global-header-hero {
+  position: absolute;
+  z-index: 99;
+  width: 100%;
+}
+html.js #global-header-hero > .container {
+  width: 100%;
+  border-bottom: 2px #ccc solid;
+}
+html.js #global-header-hero img {
+  height: 30px;
+  width: auto;
+  margin: 10px 0;
+}
+html.js #global-header-hero .row-fluid {
+  width: 95%;
+  margin: 0 auto;
+}
+html.js #global-header-hero .block-webauth {
+  margin: 14px 0;
+}
+html.js #hero-menu {
+  max-width: 1170px;
+  margin: 20px auto 0;
+}
+@media (max-width: 836px) {
+  html.js #hero-menu {
+    display: none;
+  }
+}
+html.js #hero-menu ul {
+  display: table;
+  width: 100%;
+}
+html.js #hero-menu ul ul,
+html.js #hero-menu ul .caret {
+  display: none;
+}
+html.js #hero-menu li {
+  display: table-cell;
+  list-style: none;
+  position: relative;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+}
+html.js #hero-menu li a {
+  color: #fff;
+  font-size: 20px;
+  margin-bottom: 7px;
+  display: inline-block;
+}
+html.js #hero-menu li a:before {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 3px;
+  bottom: 0;
+  left: 0;
+  background: #ffffff;
+  visibility: hidden;
+  border-radius: 5px;
+  transform: scaleX(0);
+  transition: .25s linear;
+}
+html.js #hero-menu li a:hover, html.js #hero-menu li a:focus {
+  background-color: transparent;
+}
+html.js #hero-menu li a:hover:before, html.js #hero-menu li a:focus:before {
+  visibility: visible;
+  transform: scaleX(1);
+}

--- a/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
+++ b/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
@@ -20,12 +20,15 @@ html.js body > div[class*="hero"]:not([class*="reveal"]) .entity-paragraphs-item
   margin-bottom: 0;
 }
 html.js body > .hero-curtain {
-  background: #000;
+  background: transparent;
   position: relative;
   z-index: 10;
 }
+html.js body > .hero-curtain .entity {
+  background: #000;
+}
 html.js body > .hero-curtain.below-hero {
-  margin-bottom: 0 !important;
+  padding-bottom: 0 !important;
 }
 html.js body > .hero-curtain-reveal {
   position: fixed;

--- a/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
+++ b/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
@@ -88,7 +88,6 @@ html.js #hero-menu li {
   display: table-cell;
   list-style: none;
   position: relative;
-  margin: 0;
   padding: 0;
   text-align: center;
 }
@@ -99,7 +98,7 @@ html.js #hero-menu li a {
   display: inline-block;
 }
 html.js #hero-menu li a:before {
-  content: "";
+  content: '';
   position: absolute;
   width: 100%;
   height: 3px;

--- a/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
+++ b/modules/stanford_bean_types_hero/css/stanford_bean_types_hero.css
@@ -22,7 +22,10 @@ html.js body > div[class*="hero"]:not([class*="reveal"]) .entity-paragraphs-item
 html.js body > .hero-curtain {
   background: transparent;
   position: relative;
+}
+html.js body > .hero-curtain > * {
   z-index: 10;
+  position: relative;
 }
 html.js body > .hero-curtain .entity {
   background: #000;

--- a/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
+++ b/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
@@ -1,7 +1,7 @@
 (function ($) {
   Drupal.behaviors.stanfordBeanTypesHero = {
     attach: function (context, settings) {
-      console.log(settings);
+
       var classes = ['hero-curtain', 'hero-static', 'hero-scroll'];
       var menu = $('<div>', {id: 'hero-menu', html: $('.region-navigation div > ul').clone()});
       if (!settings.stanford_bean_types_hero.heroMenu) {

--- a/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
+++ b/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
@@ -4,7 +4,7 @@
       console.log(settings);
       var classes = ['hero-curtain', 'hero-static', 'hero-scroll'];
       var menu = $('<div>', {id: 'hero-menu', html: $('.region-navigation div > ul').clone()});
-      if (settings.stanford_bean_types_hero.heroMenu) {
+      if (!settings.stanford_bean_types_hero.heroMenu) {
         menu = null;
       }
 

--- a/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
+++ b/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
@@ -41,7 +41,7 @@
             .height(winHeight)
             .css('overflow', 'hidden');
         });
-        $('.hero-curtain').css('margin-bottom', $('.hero-curtain-reveal').height());
+        $('.hero-curtain').css('padding-bottom', $('.hero-curtain-reveal').height());
       }
 
       function heroScroller() {

--- a/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
+++ b/modules/stanford_bean_types_hero/js/stanford_bean_types_hero.js
@@ -1,12 +1,18 @@
 (function ($) {
   Drupal.behaviors.stanfordBeanTypesHero = {
     attach: function (context, settings) {
+      console.log(settings);
       var classes = ['hero-curtain', 'hero-static', 'hero-scroll'];
+      var menu = $('<div>', {id: 'hero-menu', html: $('.region-navigation div > ul').clone()});
+      if (settings.stanford_bean_types_hero.heroMenu) {
+        menu = null;
+      }
 
       $.each(classes, function (i, heroClass) {
         // Move the hero to the top of the body tag.
         $('.' + heroClass, context).each(function (i, a, b) {
-          var clonedBlock = $(this).detach().prependTo('body');
+          var clonedBlock = $(this).detach().prependTo('body')
+            .prepend($('#global-header').clone().attr('id', 'global-header-hero').append(menu));
           var wrapper = $('<div>', {class: heroClass + '-reveal'});
           $(clonedBlock).siblings().wrapAll(wrapper);
         });

--- a/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
+++ b/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
@@ -33,13 +33,17 @@ html.js {
     }
 
     .hero-curtain {
-      background: #000;
+      background: transparent;
       position: relative;
       z-index: 10;
 
+      .entity {
+        background: #000;
+      }
+
       &.below-hero {
         // Need this to override the margin set by javascript.
-        margin-bottom: 0 !important;
+        padding-bottom: 0 !important;
       }
     }
 

--- a/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
+++ b/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
@@ -69,4 +69,88 @@ html.js {
 
     }
   }
+
+  #global-header-hero {
+    position: absolute;
+    z-index: 99;
+    width: 100%;
+
+    > .container {
+      width: 100%;
+      border-bottom: 2px #ccc solid;
+    }
+
+    img {
+      height: 30px;
+      width: auto;
+      margin: 10px 0;
+    }
+
+    .row-fluid {
+      width: 95%;
+      margin: 0 auto;
+    }
+
+    .block-webauth {
+      margin: 14px 0;
+    }
+  }
+
+  #hero-menu {
+    max-width: 1170px;
+    margin: 20px auto 0;
+
+    @media(max-width: 836px) {
+      display: none;
+    }
+
+    ul {
+      display: table;
+      width: 100%;
+
+      ul,
+      .caret {
+        display: none;
+      }
+    }
+    li {
+      display: table-cell;
+      list-style: none;
+      position: relative;
+      margin: 0;
+      padding: 0;
+      text-align: center;
+
+      a {
+        color: #fff;
+        font-size: 20px;
+        margin-bottom: 7px;
+        display: inline-block;
+
+        &:before {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 3px;
+          bottom: 0;
+          left: 0;
+          background: #ffffff;
+          visibility: hidden;
+          border-radius: 5px;
+          transform: scaleX(0);
+          transition: .25s linear;
+        }
+
+        &:hover,
+        &:focus {
+          background-color: transparent;
+
+          &:before {
+            visibility: visible;
+            transform: scaleX(1);
+          }
+        }
+      }
+    }
+  }
 }

--- a/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
+++ b/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
@@ -113,11 +113,11 @@ html.js {
         display: none;
       }
     }
+
     li {
       display: table-cell;
       list-style: none;
       position: relative;
-      margin: 0;
       padding: 0;
       text-align: center;
 
@@ -128,7 +128,7 @@ html.js {
         display: inline-block;
 
         &:before {
-          content: "";
+          content: '';
           position: absolute;
           width: 100%;
           height: 3px;

--- a/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
+++ b/modules/stanford_bean_types_hero/scss/stanford_bean_types_hero.scss
@@ -35,7 +35,11 @@ html.js {
     .hero-curtain {
       background: transparent;
       position: relative;
-      z-index: 10;
+
+      > * {
+        z-index: 10;
+        position: relative;
+      }
 
       .entity {
         background: #000;

--- a/modules/stanford_bean_types_hero/stanford_bean_types_hero.module
+++ b/modules/stanford_bean_types_hero/stanford_bean_types_hero.module
@@ -12,6 +12,12 @@ include_once 'stanford_bean_types_hero.features.inc';
  */
 function stanford_bean_types_hero_entity_view($entity, $type, $view_mode, $langcode) {
   if ($type == 'bean' && $entity->type == 'stanford_hero_block') {
+    $setting = array(
+      'stanford_bean_types_hero' => array(
+        'heroMenu' => variable_get('stanford_bean_types_hero_menu', FALSE),
+      ),
+    );
+    drupal_add_js($setting, array('type' => 'setting'));
     $path = drupal_get_path('module', 'stanford_bean_types_hero');
     $entity->content['#attached']['css'][] = "$path/css/stanford_bean_types_hero.css";
     $entity->content['#attached']['js'][] = "$path/js/stanford_bean_types_hero.js";


### PR DESCRIPTION
# READY FOR REVIEW
# Summary
- Added branding overlay with possible menu overlay

# Needed By (Date)
- 7/6

# Urgency
- not urgent

# Steps to Test

1. checkout branch
2. enable stanford_bean_types_hero
3. create new block of type `stanford_hero_block`
4. verify stanford branding overlays the hero block at the very top. Should be transparent with white stanford name & bottom border
5. run `drush vset stanford_bean_types_hero_menu 1`
6. reload page
7. Overlay should now contain the top main menu links.
